### PR TITLE
Fixed connection issue in Internet Explorer 8+

### DIFF
--- a/jquery.xmpp.js
+++ b/jquery.xmpp.js
@@ -20,6 +20,47 @@
  */
 
 (function($) {
+
+	// Intercept XHRs coming from IE8+ and send via XDomainRequest.
+	$.ajaxTransport("+*", function( options, originalOptions, jqXHR ) {
+    
+		// If this is IE and XDomainRequest is supported.
+		if($.browser.msie && window.XDomainRequest) {
+        
+			var xdr;
+        
+			return {
+            
+				send: function( headers, completeCallback ) {
+
+					// Use Microsoft XDR
+					xdr = new XDomainRequest();
+                
+					// Open the remote URL.
+					xdr.open("post", options.url);
+                
+					xdr.onload = function() {               
+						completeCallback(200, "success", [this.responseText]);  
+					};
+                
+					xdr.ontimeout = function(){
+						completeCallback(408, "error", ["The request timed out."]);
+					};
+                
+					xdr.onerror = function(errorText){
+						completeCallback(404, "error: " + errorText, ["The requested resource could not be found."]);
+					};
+                
+					// Submit the data to the site.
+					xdr.send(options.data);
+				},
+				abort: function() {
+					if(xdr)xdr.abort();
+				}
+			};
+		}
+    });
+
     $.xmpp ={
         rid:null,
         sid:null,


### PR DESCRIPTION
If the http-bind URL was on a different domain to the page running the
plugin, $.ajax would fail in Internet Explorer and a connection to the
server would not be made.

I've added some code to intercept $.ajax when coming from IE8 and above
(it doesn't work in anything lower than IE8 unfortunately) and then send
it via IE's built in XDomainRequest function.

The code originated from the jQuery forum at
http://forum.jquery.com/topic/cross-domain-ajax-and-ie#14737000002203097,
although I slightly modified it to better fit this purpose.
